### PR TITLE
Implement generic byte reader

### DIFF
--- a/src/endian.rs
+++ b/src/endian.rs
@@ -1,3 +1,4 @@
+use crate::read_bytes::FromBytes;
 use std::io;
 use std::io::prelude::*;
 
@@ -9,44 +10,8 @@ pub enum Endian {
 
 // figure out if there is a way to consolidate some of these with generics. A type that all from_xx_bytes implement
 impl Endian {
-    pub fn read_int32<R: Read>(&self, reader: &mut R) -> io::Result<i32> {
-        let mut buffer = [0; 4];
-        reader.read_exact(&mut buffer)?; // need error handling in case not 4 bytes?
-
-        match self {
-            Endian::Big => Ok(i32::from_be_bytes(buffer)),
-            Endian::Little => Ok(i32::from_le_bytes(buffer)),
-        }
-    }
-
-    pub fn read_int16<R: Read>(&self, reader: &mut R) -> io::Result<i16> {
-        let mut buffer = [0; 2];
-        reader.read_exact(&mut buffer)?; // need error handling in case not 4 bytes?
-
-        match self {
-            Endian::Big => Ok(i16::from_be_bytes(buffer)),
-            Endian::Little => Ok(i16::from_le_bytes(buffer)),
-        }
-    }
-
-    pub fn read_u8<R: Read>(&self, reader: &mut R) -> io::Result<u8> {
-        let mut buffer = [0; 1];
-        reader.read_exact(&mut buffer)?; // need error handling in case not 4 bytes?
-
-        match self {
-            Endian::Big => Ok(u8::from_be_bytes(buffer)),
-            Endian::Little => Ok(u8::from_le_bytes(buffer)),
-        }
-    }
-
-    pub fn read_f32<R: Read>(&self, reader: &mut R) -> io::Result<f32> {
-        let mut buffer = [0; 4];
-        reader.read_exact(&mut buffer)?; // need error handling in case not 4 bytes?
-
-        match self {
-            Endian::Big => Ok(f32::from_be_bytes(buffer)),
-            Endian::Little => Ok(f32::from_le_bytes(buffer)),
-        }
+    pub fn read<T: FromBytes>(self, reader: &mut impl Read) -> io::Result<T> {
+        T::from_bytes(self, reader)
     }
 }
 


### PR DESCRIPTION
Unfortunately, in the midst of "rebasing" the hard way, I forgot that you're not a fan of rustfmt. Some of these changes just move white space and commas. >.>

This version of the change works a little differently from the old one, because it doesn't try to extend the reader. I mean, looking at what I had before, I imagine there was some kind of a reason for it, but I think that it went beyond the scope of just deduplicating some of these functions, and so it makes sense to me (at least in hindsight) not to do it again.

What this winds up doing is adding new code in the form of a `FromBytes` trait (implemented on u8, i16, i32, and f32) and removing code in the form of specialized methods reading those values from the implementations of `Endian` and `ReadBytes`.